### PR TITLE
Properly escape variables in pytest.yml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-{{ matrix.runner }}-pip-${{ hashFiles('**/setup.py', '**/requirements.txt') }}
+          key: ${{ runner.os }}-${{ matrix.runner }}-pip-${{ hashFiles('**/setup.py', '**/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-{{ matrix.runner }}-pip-
+            ${{ runner.os }}-${{ matrix.runner }}-pip-
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
Whoops, typo here on my part that's stopping the caching from working.