### PR TITLE
Don't publish docs on PR, add workflow trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,12 @@
 name: Docs
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - main  # or your default branch name
-  pull_request:
-    branches:
       - main
+
+
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR removes doc publishing on PRs. This is so the docs always match `main`...

But I also added a "workflow trigger", which will let you go in and select a branch from the "docs" action's dropdown and manually publish the docs. Wdyt @benlebrun ?